### PR TITLE
Android N and newer works diferent

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkBridgeEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkBridgeEngine.java
@@ -122,8 +122,10 @@ public class XWalkBridgeEngine implements CordovaWebViewEngine {
         XWalkBridgeEngine.checkedShouldMakeXwalkWebView = true;
         
         // only for Nougat and newer versions
-        if (android.os.Build.VERSION.SDK_INT >= 24)
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            XWalkBridgeEngine.cachedShouldMakeXwalkWebView = false;
             return false;
+        }
         
         PackageManager packageManager = context.getPackageManager();
         int enabledSetting = packageManager.getApplicationEnabledSetting("com.google.android.webview");

--- a/platforms/android/src/org/crosswalk/engine/XWalkBridgeEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkBridgeEngine.java
@@ -120,6 +120,11 @@ public class XWalkBridgeEngine implements CordovaWebViewEngine {
         }
 
         XWalkBridgeEngine.checkedShouldMakeXwalkWebView = true;
+        
+        // only for Nougat and newer versions
+        if (android.os.Build.VERSION.SDK_INT >= 24)
+            return false;
+        
         PackageManager packageManager = context.getPackageManager();
         int enabledSetting = packageManager.getApplicationEnabledSetting("com.google.android.webview");
         if (enabledSetting != PackageManager.COMPONENT_ENABLED_STATE_ENABLED && enabledSetting != PackageManager.COMPONENT_ENABLED_STATE_DEFAULT) {


### PR DESCRIPTION
https://forums.androidcentral.com/nexus-6p/718833-android-system-webview-disabled.html

"Android N no longer uses webview but uses chrome now for rendering web in apps.

this is one of the feature google introduced in N to reduce battery by using 1 browser rather than maintaining webview and chrome at the same time"