### PR TITLE
Fix for Cordova-Android 7.0.0 so it compiles again

### DIFF
--- a/platforms/android/xwalk.gradle
+++ b/platforms/android/xwalk.gradle
@@ -29,7 +29,13 @@ def DEFAULT_MIN_SDK_VERSION = 14
 
 def getConfigPreference(name) {
     name = name.toLowerCase()
-    def xml = file("res/xml/config.xml").getText()
+    def xmlfile = file("res/xml/config.xml");
+    def xml = ""
+    if (!xmlfile.exists()) {
+      xml = file("src/main/res/xml/config.xml").getText()
+    } else {
+      xml = xmlfile.getText();
+    }
     // Disable namespace awareness since Cordova doesn't use them properly
     def root = new XmlParser(false, false).parseText(xml)
 


### PR DESCRIPTION
For Cordova-Android 7.0, Cordova changing the project structure so that Android projects have a modern directory structure like they would if you generated them in Android Studio.  Since you've adopted the Crosswalk project, here's a PR for keeping Crosswalk working with Cordova-Android 7.0.0, which should be coming out in the next week or so.

AFAIK, Crosswalk still won't work properly with Android Studio due to NDK conflicts, but this doesn't break the CLI.  I tested this against the current master of Cordova and against 6.4.x